### PR TITLE
Get installed_version from PMS executable instead of synopkg

### DIFF
--- a/update-plex.sh
+++ b/update-plex.sh
@@ -152,7 +152,8 @@ function set_available_version() {
 }
 
 function set_installed_version() {
-  installed_version=$(synopkg version 'Plex Media Server')
+  installed_version=$(/var/packages/Plex\ Media\ Server/target/Plex\ Media\ Server --version)
+  installed_version=${installed_version:1}
   echo "Installed version: $installed_version"
 }
 


### PR DESCRIPTION
This PR intends to solve [Issue#28](https://github.com/cowboy/synology-update-plex/issues/28). For more information please review the comments associated with [Issue#28](https://github.com/cowboy/synology-update-plex/issues/28)