### PR TITLE
Add update Chromecast profile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First, SSH into your NAS, save the [latest release][release] update-plex.sh scri
 
 ```sh
 $ ssh you@IP_OF_YOUR_NAS
-you@yournas:~$ wget "https://github.com/cowboy/synology-update-plex/releases/latest/download/update-plex.sh"
+you@yournas:~$ wget "https://raw.githubusercontent.com/imrivera/synology-update-plex/add_update_chromecast_profile_option/update-plex.sh"
 you@yournas:~$ chmod a+x update-plex.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Then, create a Scheduled Task with a User-defined script in the Synology DSM Con
 - Ensure the User is `root`
 - Ensure the Run command is `/path/to/update-plex.sh`
 - Add the `--plex-pass` option (eg. `/path/to/update-plex.sh --plex-pass`) if you have Plex Pass and want to enable early access / beta releases
+- Add the `--update-chromecast` if you want to update the Chromecast profile to be able to directly stream without transcoding newer codecs like H.265, EAC3, etc. to Chromecast devices (see [ambroisemaupate's Github](https://github.com/ambroisemaupate/plex-profiles))
 
 ## Caveats
 
@@ -57,7 +58,7 @@ If you find a bug or an issue not listed here, please [file an issue][issue] or 
 Adapted from work first published at:
 - https://forums.plex.tv/t/script-to-auto-update-plex-on-synology-nas-rev4/479748
 
-Inlcuding other update scripts such as:
+Including other update scripts such as:
 - https://github.com/martinorob/plexupdate
 - https://github.com/nitantsoni/plexupdate
 - https://gist.github.com/seanhamlin/dcde16a164377dca87a798a4c2ea051c

--- a/update-plex.sh
+++ b/update-plex.sh
@@ -40,7 +40,7 @@ function process_args() {
       --plex-pass)
         plex_pass=1
         ;;
-      --update_chromecast)
+      --update-chromecast)
         update_chromecast=1
         ;;
       *)

--- a/update-plex.sh
+++ b/update-plex.sh
@@ -295,6 +295,7 @@ function main() {
   shopt -s nullglob
 
   plex_pass=
+  update_chromecast=
   process_args "$@"
 
   tmp_dir=


### PR DESCRIPTION
Add a new option to allow overwriting the Chromecast.xml profile.

The updated profile allows direct streaming without transcoding of newer codecs to Chromecast devices like H265, EAC3, etc.