### PR TITLE
Strip build suffix before comparing versions

### DIFF
--- a/update-plex.sh
+++ b/update-plex.sh
@@ -178,10 +178,13 @@ function version_lte() {
 function check_up_to_date() {
   set_available_version
   set_installed_version
+  
+  local available_version_no_build=${available_version/%-*}
+  local installed_version_no_build=${installed_version/%-*}
 
   echo
-  if version_lte "$available_version" "$installed_version"; then
-    if [[ "$installed_version" != "$available_version" ]]; then
+  if version_lte "$available_version_no_build" "$installed_version_no_build"; then
+    if [[ "$installed_version_no_build" != "$available_version_no_build" ]]; then
       echo 'The installed version of Plex is newer than the available version. If' \
         'you have Plex Pass, be sure to run this script with the --plex-pass option.'
     fi


### PR DESCRIPTION
I finally updated my NAS to DSM 7 and noticed that the version installed by manually uploading `PlexMediaServer-1.32.2.7002-86cfcc10c-x86_64_DSM7.spk` was showing as `1.32.2.7002-7000` and not `1.32.2.7002-86cfcc10c`.

This update ignores the build suffix when comparing versions.